### PR TITLE
Fix service provider to work with Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "illuminate/database": "^5.3"
+        "illuminate/database": "^5.3 | ^5.4 | ^5.5 | ^5.6"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "illuminate/database": "^5.3 | ^5.4 | ^5.5 | ^5.6"
+        "illuminate/database": "5.3.*|5.4.*|5.5.*|5.6.*"
     },
     "extra": {
         "laravel": {

--- a/src/MariaDBServiceProvider.php
+++ b/src/MariaDBServiceProvider.php
@@ -8,10 +8,10 @@ class MariaDBServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $this->app->resolving('db', function ($db, $app) {
-            $db->extend('mariadb', function ($config) use ($app){
-                return (new ConnectionFactory($app))->make($config);
-            });
+        $app = $this->app;
+
+        $app['db']->extend('mariadb', function ($config) use ($app) {
+            return (new ConnectionFactory($app))->make($config);
         });
     }
 }


### PR DESCRIPTION
Use a different method to extend `db` so some L5.6 packages like lanin/laravel-api-debugger stop complaining about an `Unsupported driver: [mariadb]`