### PR TITLE
wrap as segments

### DIFF
--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -12,7 +12,9 @@ class QueryGrammar extends MySqlGrammar
     {
         $path = explode('->', $value);
 
-        $field = $this->wrapValue(array_shift($path));
+        $field = collect(explode('.', array_shift($path)))->map(function ($part) {
+            return $this->wrapValue($part);
+        })->implode('.');
 
         return sprintf('JSON_EXTRACT(%s, \'$.%s\')', $field, collect($path)->map(function ($part) {
             return '"'.$part.'"';


### PR DESCRIPTION
allows fields that include the table name to be correctly wrapped

example: `categories.meta->h1`

**before**
```sql
JSON_EXTRACT(`categories.meta`, '$."h1"')
```

**after**
```sql
JSON_EXTRACT(`categories`.`meta`, '$."h1"')
```